### PR TITLE
Use correct namespaced target

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -91,7 +91,7 @@ add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 
 
 target_link_libraries(${PROJECT_NAME}
-    realsense2
+    realsense2::realsense2
     ${catkin_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     )


### PR DESCRIPTION
Update to use exported target (namespaced target). This is the install export target name that has the correct dependencies setup on it. This should fix the issue with missing symbols.


